### PR TITLE
Rename ASSERT macro to RTREE_ASSERT

### DIFF
--- a/RTree.h
+++ b/RTree.h
@@ -13,7 +13,7 @@
 #include <functional>
 #include <vector>
 
-#define ASSERT assert // RTree uses ASSERT( condition )
+#define RTREE_ASSERT assert // RTree uses RTREE_ASSERT( condition )
 #ifndef Min
   #define Min std::min
 #endif //Min
@@ -143,7 +143,7 @@ public:
     /// Access the current data element. Caller must be sure iterator is not NULL first.
     DATATYPE& operator*()
     {
-      ASSERT(IsNotNull());
+      RTREE_ASSERT(IsNotNull());
       StackElement& curTos = m_stack[m_tos - 1];
       return curTos.m_node->m_branch[curTos.m_branchIndex].m_data;
     }
@@ -151,7 +151,7 @@ public:
     /// Access the current data element. Caller must be sure iterator is not NULL first.
     const DATATYPE& operator*() const
     {
-      ASSERT(IsNotNull());
+      RTREE_ASSERT(IsNotNull());
       StackElement& curTos = m_stack[m_tos - 1];
       return curTos.m_node->m_branch[curTos.m_branchIndex].m_data;
     }
@@ -162,7 +162,7 @@ public:
     /// Get the bounds for this node
     void GetBounds(ELEMTYPE a_min[NUMDIMS], ELEMTYPE a_max[NUMDIMS])
     {
-      ASSERT(IsNotNull());
+      RTREE_ASSERT(IsNotNull());
       StackElement& curTos = m_stack[m_tos - 1];
       Branch& curBranch = curTos.m_node->m_branch[curTos.m_branchIndex];
 
@@ -227,13 +227,13 @@ public:
       m_stack[m_tos].m_node = a_node;
       m_stack[m_tos].m_branchIndex = a_branchIndex;
       ++m_tos;
-      ASSERT(m_tos <= MAX_STACK);
+      RTREE_ASSERT(m_tos <= MAX_STACK);
     }
 
     /// Pop element off iteration stack (For internal use only)
     StackElement& Pop()
     {
-      ASSERT(m_tos > 0);
+      RTREE_ASSERT(m_tos > 0);
       --m_tos;
       return m_stack[m_tos];
     }
@@ -427,28 +427,28 @@ public:
   template< typename TYPE >
   size_t Write(const TYPE& a_value)
   {
-    ASSERT(m_file);
+    RTREE_ASSERT(m_file);
     return fwrite((void*)&a_value, sizeof(a_value), 1, m_file);
   }
 
   template< typename TYPE >
   size_t WriteArray(const TYPE* a_array, int a_count)
   {
-    ASSERT(m_file);
+    RTREE_ASSERT(m_file);
     return fwrite((void*)a_array, sizeof(TYPE) * a_count, 1, m_file);
   }
 
   template< typename TYPE >
   size_t Read(TYPE& a_value)
   {
-    ASSERT(m_file);
+    RTREE_ASSERT(m_file);
     return fread((void*)&a_value, sizeof(a_value), 1, m_file);
   }
 
   template< typename TYPE >
   size_t ReadArray(TYPE* a_array, int a_count)
   {
-    ASSERT(m_file);
+    RTREE_ASSERT(m_file);
     return fread((void*)a_array, sizeof(TYPE) * a_count, 1, m_file);
   }
 };
@@ -457,8 +457,8 @@ public:
 RTREE_TEMPLATE
 RTREE_QUAL::RTree()
 {
-  ASSERT(MAXNODES > MINNODES);
-  ASSERT(MINNODES > 0);
+  RTREE_ASSERT(MAXNODES > MINNODES);
+  RTREE_ASSERT(MINNODES > 0);
 
   // Precomputed volumes of the unit spheres for the first few dimensions
   const float UNIT_SPHERE_VOLUMES[] = {
@@ -497,7 +497,7 @@ void RTREE_QUAL::Insert(const ELEMTYPE a_min[NUMDIMS], const ELEMTYPE a_max[NUMD
 #ifdef _DEBUG
   for(int index=0; index<NUMDIMS; ++index)
   {
-    ASSERT(a_min[index] <= a_max[index]);
+    RTREE_ASSERT(a_min[index] <= a_max[index]);
   }
 #endif //_DEBUG
 
@@ -521,7 +521,7 @@ void RTREE_QUAL::Remove(const ELEMTYPE a_min[NUMDIMS], const ELEMTYPE a_max[NUMD
 #ifdef _DEBUG
   for(int index=0; index<NUMDIMS; ++index)
   {
-    ASSERT(a_min[index] <= a_max[index]);
+    RTREE_ASSERT(a_min[index] <= a_max[index]);
   }
 #endif //_DEBUG
 
@@ -543,7 +543,7 @@ int RTREE_QUAL::Search(const ELEMTYPE a_min[NUMDIMS], const ELEMTYPE a_max[NUMDI
 #ifdef _DEBUG
   for(int index=0; index<NUMDIMS; ++index)
   {
-    ASSERT(a_min[index] <= a_max[index]);
+    RTREE_ASSERT(a_min[index] <= a_max[index]);
   }
 #endif //_DEBUG
 
@@ -848,8 +848,8 @@ void RTREE_QUAL::Reset()
 RTREE_TEMPLATE
 void RTREE_QUAL::RemoveAllRec(Node* a_node)
 {
-  ASSERT(a_node);
-  ASSERT(a_node->m_level >= 0);
+  RTREE_ASSERT(a_node);
+  RTREE_ASSERT(a_node->m_level >= 0);
 
   if(a_node->IsInternalNode()) // This is an internal node in the tree
   {
@@ -879,7 +879,7 @@ typename RTREE_QUAL::Node* RTREE_QUAL::AllocNode()
 RTREE_TEMPLATE
 void RTREE_QUAL::FreeNode(Node* a_node)
 {
-  ASSERT(a_node);
+  RTREE_ASSERT(a_node);
 
 #ifdef RTREE_DONT_USE_MEMPOOLS
   delete a_node;
@@ -942,8 +942,8 @@ void RTREE_QUAL::InitRect(Rect* a_rect)
 RTREE_TEMPLATE
 bool RTREE_QUAL::InsertRectRec(const Branch& a_branch, Node* a_node, Node** a_newNode, int a_level)
 {
-  ASSERT(a_node && a_newNode);
-  ASSERT(a_level >= 0 && a_level <= a_node->m_level);
+  RTREE_ASSERT(a_node && a_newNode);
+  RTREE_ASSERT(a_level >= 0 && a_level <= a_node->m_level);
 
   // recurse until we reach the correct level for the new record. data records
   // will always be called with a_level == 0 (leaf)
@@ -987,7 +987,7 @@ bool RTREE_QUAL::InsertRectRec(const Branch& a_branch, Node* a_node, Node** a_ne
   else
   {
     // Should never occur
-    ASSERT(0);
+    RTREE_ASSERT(0);
     return false;
   }
 }
@@ -1003,12 +1003,12 @@ bool RTREE_QUAL::InsertRectRec(const Branch& a_branch, Node* a_node, Node** a_ne
 RTREE_TEMPLATE
 bool RTREE_QUAL::InsertRect(const Branch& a_branch, Node** a_root, int a_level)
 {
-  ASSERT(a_root);
-  ASSERT(a_level >= 0 && a_level <= (*a_root)->m_level);
+  RTREE_ASSERT(a_root);
+  RTREE_ASSERT(a_level >= 0 && a_level <= (*a_root)->m_level);
 #ifdef _DEBUG
   for(int index=0; index < NUMDIMS; ++index)
   {
-    ASSERT(a_branch.m_rect.m_min[index] <= a_branch.m_rect.m_max[index]);
+    RTREE_ASSERT(a_branch.m_rect.m_min[index] <= a_branch.m_rect.m_max[index]);
   }
 #endif //_DEBUG
 
@@ -1046,7 +1046,7 @@ bool RTREE_QUAL::InsertRect(const Branch& a_branch, Node** a_root, int a_level)
 RTREE_TEMPLATE
 typename RTREE_QUAL::Rect RTREE_QUAL::NodeCover(Node* a_node)
 {
-  ASSERT(a_node);
+  RTREE_ASSERT(a_node);
 
   Rect rect = a_node->m_branch[0].m_rect;
   for(int index = 1; index < a_node->m_count; ++index)
@@ -1065,8 +1065,8 @@ typename RTREE_QUAL::Rect RTREE_QUAL::NodeCover(Node* a_node)
 RTREE_TEMPLATE
 bool RTREE_QUAL::AddBranch(const Branch* a_branch, Node* a_node, Node** a_newNode)
 {
-  ASSERT(a_branch);
-  ASSERT(a_node);
+  RTREE_ASSERT(a_branch);
+  RTREE_ASSERT(a_node);
 
   if(a_node->m_count < MAXNODES)  // Split won't be necessary
   {
@@ -1077,7 +1077,7 @@ bool RTREE_QUAL::AddBranch(const Branch* a_branch, Node* a_node, Node** a_newNod
   }
   else
   {
-    ASSERT(a_newNode);
+    RTREE_ASSERT(a_newNode);
 
     SplitNode(a_node, a_branch, a_newNode);
     return true;
@@ -1090,8 +1090,8 @@ bool RTREE_QUAL::AddBranch(const Branch* a_branch, Node* a_node, Node** a_newNod
 RTREE_TEMPLATE
 void RTREE_QUAL::DisconnectBranch(Node* a_node, int a_index)
 {
-  ASSERT(a_node && (a_index >= 0) && (a_index < MAXNODES));
-  ASSERT(a_node->m_count > 0);
+  RTREE_ASSERT(a_node && (a_index >= 0) && (a_index < MAXNODES));
+  RTREE_ASSERT(a_node->m_count > 0);
 
   // Remove element by swapping with the last element to prevent gaps in array
   a_node->m_branch[a_index] = a_node->m_branch[a_node->m_count - 1];
@@ -1108,7 +1108,7 @@ void RTREE_QUAL::DisconnectBranch(Node* a_node, int a_index)
 RTREE_TEMPLATE
 int RTREE_QUAL::PickBranch(const Rect* a_rect, Node* a_node)
 {
-  ASSERT(a_rect && a_node);
+  RTREE_ASSERT(a_rect && a_node);
 
   bool firstTime = true;
   ELEMTYPEREAL increase;
@@ -1146,7 +1146,7 @@ int RTREE_QUAL::PickBranch(const Rect* a_rect, Node* a_node)
 RTREE_TEMPLATE
 typename RTREE_QUAL::Rect RTREE_QUAL::CombineRect(const Rect* a_rectA, const Rect* a_rectB)
 {
-  ASSERT(a_rectA && a_rectB);
+  RTREE_ASSERT(a_rectA && a_rectB);
 
   Rect newRect;
 
@@ -1168,8 +1168,8 @@ typename RTREE_QUAL::Rect RTREE_QUAL::CombineRect(const Rect* a_rectA, const Rec
 RTREE_TEMPLATE
 void RTREE_QUAL::SplitNode(Node* a_node, const Branch* a_branch, Node** a_newNode)
 {
-  ASSERT(a_node);
-  ASSERT(a_branch);
+  RTREE_ASSERT(a_node);
+  RTREE_ASSERT(a_branch);
 
   // Could just use local here, but member or external is faster since it is reused
   PartitionVars localVars;
@@ -1189,7 +1189,7 @@ void RTREE_QUAL::SplitNode(Node* a_node, const Branch* a_branch, Node** a_newNod
   a_node->m_count = 0;
   LoadNodes(a_node, *a_newNode, parVars);
 
-  ASSERT((a_node->m_count + (*a_newNode)->m_count) == parVars->m_total);
+  RTREE_ASSERT((a_node->m_count + (*a_newNode)->m_count) == parVars->m_total);
 }
 
 
@@ -1197,7 +1197,7 @@ void RTREE_QUAL::SplitNode(Node* a_node, const Branch* a_branch, Node** a_newNod
 RTREE_TEMPLATE
 ELEMTYPEREAL RTREE_QUAL::RectVolume(Rect* a_rect)
 {
-  ASSERT(a_rect);
+  RTREE_ASSERT(a_rect);
 
   ELEMTYPEREAL volume = (ELEMTYPEREAL)1;
 
@@ -1206,7 +1206,7 @@ ELEMTYPEREAL RTREE_QUAL::RectVolume(Rect* a_rect)
     volume *= a_rect->m_max[index] - a_rect->m_min[index];
   }
 
-  ASSERT(volume >= (ELEMTYPEREAL)0);
+  RTREE_ASSERT(volume >= (ELEMTYPEREAL)0);
 
   return volume;
 }
@@ -1216,7 +1216,7 @@ ELEMTYPEREAL RTREE_QUAL::RectVolume(Rect* a_rect)
 RTREE_TEMPLATE
 ELEMTYPEREAL RTREE_QUAL::RectSphericalVolume(Rect* a_rect)
 {
-  ASSERT(a_rect);
+  RTREE_ASSERT(a_rect);
 
   ELEMTYPEREAL sumOfSquares = (ELEMTYPEREAL)0;
   ELEMTYPEREAL radius;
@@ -1261,10 +1261,10 @@ ELEMTYPEREAL RTREE_QUAL::CalcRectVolume(Rect* a_rect)
 RTREE_TEMPLATE
 void RTREE_QUAL::GetBranches(Node* a_node, const Branch* a_branch, PartitionVars* a_parVars)
 {
-  ASSERT(a_node);
-  ASSERT(a_branch);
+  RTREE_ASSERT(a_node);
+  RTREE_ASSERT(a_branch);
 
-  ASSERT(a_node->m_count == MAXNODES);
+  RTREE_ASSERT(a_node->m_count == MAXNODES);
 
   // Load the branch buffer
   for(int index=0; index < MAXNODES; ++index)
@@ -1298,7 +1298,7 @@ void RTREE_QUAL::GetBranches(Node* a_node, const Branch* a_branch, PartitionVars
 RTREE_TEMPLATE
 void RTREE_QUAL::ChoosePartition(PartitionVars* a_parVars, int a_minFill)
 {
-  ASSERT(a_parVars);
+  RTREE_ASSERT(a_parVars);
 
   ELEMTYPEREAL biggestDiff;
   int group, chosen = 0, betterGroup = 0;
@@ -1367,8 +1367,8 @@ void RTREE_QUAL::ChoosePartition(PartitionVars* a_parVars, int a_minFill)
     }
   }
 
-  ASSERT((a_parVars->m_count[0] + a_parVars->m_count[1]) == a_parVars->m_total);
-  ASSERT((a_parVars->m_count[0] >= a_parVars->m_minFill) &&
+  RTREE_ASSERT((a_parVars->m_count[0] + a_parVars->m_count[1]) == a_parVars->m_total);
+  RTREE_ASSERT((a_parVars->m_count[0] >= a_parVars->m_minFill) &&
         (a_parVars->m_count[1] >= a_parVars->m_minFill));
 }
 
@@ -1377,20 +1377,20 @@ void RTREE_QUAL::ChoosePartition(PartitionVars* a_parVars, int a_minFill)
 RTREE_TEMPLATE
 void RTREE_QUAL::LoadNodes(Node* a_nodeA, Node* a_nodeB, PartitionVars* a_parVars)
 {
-  ASSERT(a_nodeA);
-  ASSERT(a_nodeB);
-  ASSERT(a_parVars);
+  RTREE_ASSERT(a_nodeA);
+  RTREE_ASSERT(a_nodeB);
+  RTREE_ASSERT(a_parVars);
 
   for(int index=0; index < a_parVars->m_total; ++index)
   {
-    ASSERT(a_parVars->m_partition[index] == 0 || a_parVars->m_partition[index] == 1);
+    RTREE_ASSERT(a_parVars->m_partition[index] == 0 || a_parVars->m_partition[index] == 1);
 
     int targetNodeIndex = a_parVars->m_partition[index];
     Node* targetNodes[] = {a_nodeA, a_nodeB};
 
     // It is assured that AddBranch here will not cause a node split.
     bool nodeWasSplit = AddBranch(&a_parVars->m_branchBuf[index], targetNodes[targetNodeIndex], NULL);
-    ASSERT(!nodeWasSplit);
+    RTREE_ASSERT(!nodeWasSplit);
   }
 }
 
@@ -1399,7 +1399,7 @@ void RTREE_QUAL::LoadNodes(Node* a_nodeA, Node* a_nodeB, PartitionVars* a_parVar
 RTREE_TEMPLATE
 void RTREE_QUAL::InitParVars(PartitionVars* a_parVars, int a_maxRects, int a_minFill)
 {
-  ASSERT(a_parVars);
+  RTREE_ASSERT(a_parVars);
 
   a_parVars->m_count[0] = a_parVars->m_count[1] = 0;
   a_parVars->m_area[0] = a_parVars->m_area[1] = (ELEMTYPEREAL)0;
@@ -1449,8 +1449,8 @@ void RTREE_QUAL::PickSeeds(PartitionVars* a_parVars)
 RTREE_TEMPLATE
 void RTREE_QUAL::Classify(int a_index, int a_group, PartitionVars* a_parVars)
 {
-  ASSERT(a_parVars);
-  ASSERT(PartitionVars::NOT_TAKEN == a_parVars->m_partition[a_index]);
+  RTREE_ASSERT(a_parVars);
+  RTREE_ASSERT(PartitionVars::NOT_TAKEN == a_parVars->m_partition[a_index]);
 
   a_parVars->m_partition[a_index] = a_group;
 
@@ -1478,8 +1478,8 @@ void RTREE_QUAL::Classify(int a_index, int a_group, PartitionVars* a_parVars)
 RTREE_TEMPLATE
 bool RTREE_QUAL::RemoveRect(Rect* a_rect, const DATATYPE& a_id, Node** a_root)
 {
-  ASSERT(a_rect && a_root);
-  ASSERT(*a_root);
+  RTREE_ASSERT(a_rect && a_root);
+  RTREE_ASSERT(*a_root);
 
   ListNode* reInsertList = NULL;
 
@@ -1512,7 +1512,7 @@ bool RTREE_QUAL::RemoveRect(Rect* a_rect, const DATATYPE& a_id, Node** a_root)
     {
       Node* tempNode = (*a_root)->m_branch[0].m_child;
 
-      ASSERT(tempNode);
+      RTREE_ASSERT(tempNode);
       FreeNode(*a_root);
       *a_root = tempNode;
     }
@@ -1532,8 +1532,8 @@ bool RTREE_QUAL::RemoveRect(Rect* a_rect, const DATATYPE& a_id, Node** a_root)
 RTREE_TEMPLATE
 bool RTREE_QUAL::RemoveRectRec(Rect* a_rect, const DATATYPE& a_id, Node* a_node, ListNode** a_listNode)
 {
-  ASSERT(a_rect && a_node && a_listNode);
-  ASSERT(a_node->m_level >= 0);
+  RTREE_ASSERT(a_rect && a_node && a_listNode);
+  RTREE_ASSERT(a_node->m_level >= 0);
 
   if(a_node->IsInternalNode())  // not a leaf node
   {
@@ -1579,7 +1579,7 @@ bool RTREE_QUAL::RemoveRectRec(Rect* a_rect, const DATATYPE& a_id, Node* a_node,
 RTREE_TEMPLATE
 bool RTREE_QUAL::Overlap(Rect* a_rectA, Rect* a_rectB) const
 {
-  ASSERT(a_rectA && a_rectB);
+  RTREE_ASSERT(a_rectA && a_rectB);
 
   for(int index=0; index < NUMDIMS; ++index)
   {
@@ -1611,9 +1611,9 @@ void RTREE_QUAL::ReInsert(Node* a_node, ListNode** a_listNode)
 RTREE_TEMPLATE
 bool RTREE_QUAL::Search(Node* a_node, Rect* a_rect, int& a_foundCount, std::function<bool (const DATATYPE&)> callback) const
 {
-  ASSERT(a_node);
-  ASSERT(a_node->m_level >= 0);
-  ASSERT(a_rect);
+  RTREE_ASSERT(a_node);
+  RTREE_ASSERT(a_node->m_level >= 0);
+  RTREE_ASSERT(a_rect);
 
   if(a_node->IsInternalNode())
   {
@@ -1655,8 +1655,8 @@ bool RTREE_QUAL::Search(Node* a_node, Rect* a_rect, int& a_foundCount, std::func
 RTREE_TEMPLATE
 std::vector<typename RTREE_QUAL::Rect> RTREE_QUAL::ListTree() const
 {
-  ASSERT(m_root);
-  ASSERT(m_root->m_level >= 0);
+  RTREE_ASSERT(m_root);
+  RTREE_ASSERT(m_root->m_level >= 0);
 
   std::vector<Rect> treeList;
 


### PR DESCRIPTION
Rename ASSERT macro to RTREE_ASSERT to better mitigate name clashes with other libraries or include files