### PR TITLE
Avoid Min/Max makros, if possible

### DIFF
--- a/MemoryTest.cpp
+++ b/MemoryTest.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <limits>
 #include <memory.h>
 #ifdef WIN32
   #include <crtdbg.h>

--- a/RTree.h
+++ b/RTree.h
@@ -14,11 +14,15 @@
 #include <vector>
 
 #define ASSERT assert // RTree uses ASSERT( condition )
-#ifndef Min
-  #define Min std::min
+#ifdef Min
+  #define STDMIN Min
+#else
+  #define STDMIN std::min
 #endif //Min
-#ifndef Max
-  #define Max std::max
+#ifdef Max
+  #define STDMAX Max
+#else
+  #define STDMAX std::max
 #endif //Max
 
 //
@@ -1152,8 +1156,8 @@ typename RTREE_QUAL::Rect RTREE_QUAL::CombineRect(const Rect* a_rectA, const Rec
 
   for(int index = 0; index < NUMDIMS; ++index)
   {
-    newRect.m_min[index] = Min(a_rectA->m_min[index], a_rectB->m_min[index]);
-    newRect.m_max[index] = Max(a_rectA->m_max[index], a_rectB->m_max[index]);
+    newRect.m_min[index] = STDMIN(a_rectA->m_min[index], a_rectB->m_min[index]);
+    newRect.m_max[index] = STDMAX(a_rectA->m_max[index], a_rectB->m_max[index]);
   }
 
   return newRect;

--- a/Test.cpp
+++ b/Test.cpp
@@ -5,6 +5,7 @@
 //
 
 #include <iostream>
+#include <limits>
 #include "RTree.h"
 
 using namespace std;

--- a/TestBadData.cpp
+++ b/TestBadData.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 #include "RTree.h"

--- a/TestTreeList.cpp
+++ b/TestTreeList.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <limits>
 #include "RTree.h"
 
 using namespace std;


### PR DESCRIPTION
`RTree.h` unfortunately always defines the makros `Min` and `Max`, which may lead to issues with code using one of these names as identifier, e.g. class name (example: [FastNoise2](https://github.com/Auburn/FastNoise2) in [Blends.h](https://github.com/Auburn/FastNoise2/blob/132c5348c38e71a52a9cd0e692b0381995ff8ae3/include/FastNoise/Generators/Blends.h#L134)). I suggest introducing a new makro with a name complying to usual standards (all uppercase), which takes over the value of `Min`/`Max` for projects/platforms using these makros.

Also, while compiling the tests, my compiler complained about `std::numeric_limits` not existing so I added `#include <limits>` to the tests in a separate commit.